### PR TITLE
Be more helpful when the user tries to DM an IRC channel

### DIFF
--- a/src/xmpp/biboumi_component.cpp
+++ b/src/xmpp/biboumi_component.cpp
@@ -375,6 +375,12 @@ void BiboumiComponent::handle_message(const Stanza& stanza)
               // Convert the message body into a raw IRC message
               bridge->send_raw_message(fixed_irc_server, body->get_inner());
             }
+          else
+            {
+              this->send_stanza_error("message", from_str, to_str, id,
+                                      "cancel", "not-acceptable",
+                                      "This is a regular chat rather than a groupchat. To join an IRC channel, join a groupchat instead.");
+            }
         }
     }
   else if (type == "normal" && iid.type == Iid::Type::Channel)


### PR DESCRIPTION
Biboumi is currently completely silent when a user (perhaps due to a suboptimal client UI) acidentally DMs the bridge when they mean to join an IRC channel.

FWIW: the bridge doesn't currently compile for me on debian sid without this:

```
diff --git a/src/bridge/bridge.hpp b/src/bridge/bridge.hpp
index a7aef3d..583c16c 100644
--- a/src/bridge/bridge.hpp
+++ b/src/bridge/bridge.hpp
@@ -14,6 +14,7 @@
 #include <functional>
 #include <exception>
 #include <string>
+#include <cstring>
 #include <memory>
 
 #include <biboumi.h>
```
...but this could just be a quirk of my setup so I didn't include it (assuming that master surely builds for everyone else).