### PR TITLE
fix docker tests by pinning older versions of Catch & slixmpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,8 @@ endforeach()
 #
 include(ExternalProject)
 ExternalProject_Add(catch
-  GIT_REPOSITORY "https://lab.louiz.org/louiz/Catch.git"
+  GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
+  GIT_TAG "v1.12.2"
   PREFIX "external"
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""

--- a/docker/biboumi/alpine/Dockerfile
+++ b/docker/biboumi/alpine/Dockerfile
@@ -8,7 +8,7 @@
 FROM docker.io/alpine:latest as builder
 
 RUN apk add --no-cache --virtual .build cmake expat-dev g++ git libidn-dev \
-        make postgresql-dev python2 sqlite-dev udns-dev util-linux-dev botan-dev
+        make postgresql-dev python3 sqlite-dev udns-dev util-linux-dev botan-dev
 
 
 RUN git clone https://lab.louiz.org/louiz/biboumi && \

--- a/docker/biboumi/alpine/Dockerfile
+++ b/docker/biboumi/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://lab.louiz.org/louiz/biboumi && \
              -DWITH_SQLITE3=1 \
              -DWITH_LIBIDN=1 \
              -DWITH_POSTGRESQL=1 && \
-    make -j8 && \
+    make -j$(nproc || echo 1) && \
     make install
 
 # ---

--- a/docker/test/alpine/Dockerfile
+++ b/docker/test/alpine/Dockerfile
@@ -32,4 +32,4 @@ wget
 RUN wget "https://github.com/oragono/oragono/archive/v2.0.0.tar.gz" && tar xvf "v2.0.0.tar.gz" && cd "oragono-2.0.0" && make && cp ~/go/bin/oragono /usr/local/bin
 
 # Install slixmpp, for e2e tests
-RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && python3 setup.py build && python3 setup.py install
+RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && git checkout slix-1.7.1 && python3 setup.py build && python3 setup.py install

--- a/docker/test/debian/Dockerfile
+++ b/docker/test/debian/Dockerfile
@@ -34,5 +34,4 @@ wget
 RUN wget "https://github.com/oragono/oragono/releases/download/v2.0.0/oragono-2.0.0-linux-x64.tar.gz" && tar xvf oragono-2.0.0-linux-x64.tar.gz && cp oragono-2.0.0-linux-x64/oragono /usr/local/bin
 
 # Install slixmpp, for e2e tests
-RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && python3 setup.py build && python3 setup.py install
-
+RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://codeberg.org/poezio/slixmpp.git && pip3 install pyasn1 && cd slixmpp && git checkout slix-1.7.1 && python3 setup.py build && python3 setup.py install

--- a/docker/test/fedora/Dockerfile
+++ b/docker/test/fedora/Dockerfile
@@ -35,7 +35,7 @@ rpmdevtools \
 && dnf clean all
 
 # Install slixmpp, for e2e tests
-RUN git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && python3 setup.py build && python3 setup.py install
+RUN git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && git checkout slix-1.7.1 && python3 setup.py build && python3 setup.py install
 
 # Install oragono, for e2e tests
 RUN wget "https://github.com/oragono/oragono/releases/download/v2.0.0/oragono-2.0.0-linux-x64.tar.gz" && tar xvf oragono-2.0.0-linux-x64.tar.gz && cp oragono-2.0.0-linux-x64/oragono /usr/local/bin


### PR DESCRIPTION
- Catch: lab.louiz.org is down; use catchorg/Catch2, pin latest v1
- slixmpp: broke python 3.7 in v1.8 (cf below): pin 1.7 branch

slixmpp error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/slixmpp/types.py", line 16, in <module>
    from typing import (
ImportError: cannot import name 'Literal' from 'typing' (/usr/lib/python3.7/typing.py)
```