### PR TITLE
Fix /nick spam with our away presence: send /nick only if nick changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,8 @@ endforeach()
 #
 include(ExternalProject)
 ExternalProject_Add(catch
-  GIT_REPOSITORY "https://lab.louiz.org/louiz/Catch.git"
+  GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
+  GIT_TAG "v1.12.2"
   PREFIX "external"
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ""

--- a/docker/biboumi/alpine/Dockerfile
+++ b/docker/biboumi/alpine/Dockerfile
@@ -8,7 +8,7 @@
 FROM docker.io/alpine:latest as builder
 
 RUN apk add --no-cache --virtual .build cmake expat-dev g++ git libidn-dev \
-        make postgresql-dev python2 sqlite-dev udns-dev util-linux-dev botan-dev
+        make postgresql-dev python3 sqlite-dev udns-dev util-linux-dev botan-dev
 
 
 RUN git clone https://lab.louiz.org/louiz/biboumi && \

--- a/docker/biboumi/alpine/Dockerfile
+++ b/docker/biboumi/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://lab.louiz.org/louiz/biboumi && \
              -DWITH_SQLITE3=1 \
              -DWITH_LIBIDN=1 \
              -DWITH_POSTGRESQL=1 && \
-    make -j8 && \
+    make -j$(nproc || echo 1) && \
     make install
 
 # ---

--- a/docker/test/alpine/Dockerfile
+++ b/docker/test/alpine/Dockerfile
@@ -32,4 +32,4 @@ wget
 RUN wget "https://github.com/oragono/oragono/archive/v2.0.0.tar.gz" && tar xvf "v2.0.0.tar.gz" && cd "oragono-2.0.0" && make && cp ~/go/bin/oragono /usr/local/bin
 
 # Install slixmpp, for e2e tests
-RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && python3 setup.py build && python3 setup.py install
+RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && git checkout slix-1.7.1 && python3 setup.py build && python3 setup.py install

--- a/docker/test/debian/Dockerfile
+++ b/docker/test/debian/Dockerfile
@@ -34,5 +34,4 @@ wget
 RUN wget "https://github.com/oragono/oragono/releases/download/v2.0.0/oragono-2.0.0-linux-x64.tar.gz" && tar xvf oragono-2.0.0-linux-x64.tar.gz && cp oragono-2.0.0-linux-x64/oragono /usr/local/bin
 
 # Install slixmpp, for e2e tests
-RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && python3 setup.py build && python3 setup.py install
-
+RUN git clone https://github.com/saghul/aiodns.git && cd aiodns && git checkout 7ee13f9bea25784322~ && python3 setup.py build && python3 setup.py install && git clone https://codeberg.org/poezio/slixmpp.git && pip3 install pyasn1 && cd slixmpp && git checkout slix-1.7.1 && python3 setup.py build && python3 setup.py install

--- a/docker/test/fedora/Dockerfile
+++ b/docker/test/fedora/Dockerfile
@@ -35,7 +35,7 @@ rpmdevtools \
 && dnf clean all
 
 # Install slixmpp, for e2e tests
-RUN git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && python3 setup.py build && python3 setup.py install
+RUN git clone https://lab.louiz.org/poezio/slixmpp && pip3 install pyasn1 && cd slixmpp && git checkout slix-1.7.1 && python3 setup.py build && python3 setup.py install
 
 # Install oragono, for e2e tests
 RUN wget "https://github.com/oragono/oragono/releases/download/v2.0.0/oragono-2.0.0-linux-x64.tar.gz" && tar xvf oragono-2.0.0-linux-x64.tar.gz && cp oragono-2.0.0-linux-x64/oragono /usr/local/bin

--- a/src/xmpp/biboumi_component.cpp
+++ b/src/xmpp/biboumi_component.cpp
@@ -196,7 +196,10 @@ void BiboumiComponent::handle_presence(const Stanza& stanza)
                 {
                   const auto chan = irc->find_channel(iid.get_local());
                   if (chan && chan->joined)
-                    bridge->send_irc_nick_change(iid, to.resource, from.resource);
+                    {
+                      if (!own_nick.empty() && own_nick != to.resource)
+                        bridge->send_irc_nick_change(iid, to.resource, from.resource);
+                    }
                   else
                     { // send an error if we are not joined yet, instead of treating it as a join
                       this->send_stanza_error("presence", from_str, to_str, id, "modify", "not-acceptable", "You are not joined to this MUC.");


### PR DESCRIPTION
(stack PR on top of #9)

88fe1783bfd58ea0dca9e9e507a046e5c982b779 lost the "nick has actually changed" check before sending /nick to IRC.

This reintroduces is it.

This issue became apparent with biboumi connecting to ZNC, and with multiple xmpp clients for the same JID, resulting in a lot of presence stanza, forwarded by biboumi as a lot of /nick.
Result: libera.chat didn't like it and responded regularly with:
> lead.libera.chat: MyNick: ZNC is already trying to get this nickname